### PR TITLE
Laracasts Full Width Video

### DIFF
--- a/laracasts/fullwidthvideo
+++ b/laracasts/fullwidthvideo
@@ -1,0 +1,24 @@
+// ==UserScript==
+// @name         Laracasts - Full Width Video
+// @namespace    http://tampermonkey.net/
+// @version      1.0
+// @description  try to take over the world!
+// @author       You
+// @match        https://laracasts.com/*
+// @grant        none
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    var videoPlayer = document.querySelector(".Video__player");
+    videoPlayer.style.width = '100%';
+    videoPlayer.style.maxWidth = '100%';
+    videoPlayer.style.padding = 0;
+    videoPlayer.style.margin = 0;
+    videoPlayer.style.border = 'none';
+
+    var videoWrap = document.querySelector(".Video__player-wrap");
+    videoWrap.style.border = 'none';
+
+})();


### PR DESCRIPTION
Makes the video on Laracasts extend to the full width of the viewport.

This allows for optimal viewing, specifically when split screening.
